### PR TITLE
Finance domain normalization: config-catalog baseline

### DIFF
--- a/.github/ISSUE_TEMPLATE/change-request.md
+++ b/.github/ISSUE_TEMPLATE/change-request.md
@@ -1,0 +1,22 @@
+---
+name: Change request
+about: Request a change to existing finance functionality or configuration
+title: "[Change] "
+labels: ["type:change"]
+---
+
+## Reason
+## Current behavior
+## Desired behavior
+## Affected finance areas
+## Change class
+<!-- Standard / Normal / Major / Emergency -->
+## Control impact
+## Risk
+## Dependencies
+## Acceptance criteria
+- [ ]
+
+## Test requirements
+## Rollback consideration
+## Documentation updates required

--- a/.github/ISSUE_TEMPLATE/control-improvement-request.md
+++ b/.github/ISSUE_TEMPLATE/control-improvement-request.md
@@ -1,0 +1,22 @@
+---
+name: Control improvement request
+about: Request a change to a finance control
+title: "[Control] "
+labels: ["type:control-improvement"]
+---
+
+## Reason
+## Goal
+## In scope
+## Out of scope
+## Affected finance area
+## Related control ID
+## Control impact
+## Risk
+## Dependencies
+## Acceptance criteria
+- [ ]
+
+## Test requirements
+## Rollback consideration
+## Documentation updates required

--- a/.github/ISSUE_TEMPLATE/documentation-update.md
+++ b/.github/ISSUE_TEMPLATE/documentation-update.md
@@ -1,0 +1,13 @@
+---
+name: Documentation update
+about: Request a documentation addition or update
+title: "[Docs] "
+labels: ["type:documentation"]
+---
+
+## Summary
+## Document(s) affected
+## Reason for update
+## Proposed content
+## Repository
+<!-- finance-governance / finance-automation / finance-config-catalog / finance-runbooks -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,34 @@
+## Summary
+Describe the configuration change clearly.
+
+## Related issue
+Link the related issue.
+
+## Affected configuration objects
+List specific items changed (e.g., mapping ID, control ID, journal template, asset rule, exception category).
+
+## Affected areas
+List impacted finance areas, interfaces, or controls.
+
+## Control impact
+Low / Medium / High / Critical
+
+## Downstream coordination
+- [ ] Corresponding finance-automation code updated (if mapping or validation change)
+- [ ] No automation code change needed — explain why: <!-- e.g., documentation-only, no logic change -->
+
+## Validation performed
+Describe how the configuration change was verified (e.g., reviewed against Exact Online, cross-checked with source data).
+
+## Rollback approach
+How can this be reversed?
+
+## AI assistance
+- [ ] Claude Code was used in preparing this change
+
+## Checklist
+- [ ] Linked issue exists
+- [ ] Control impact assessed
+- [ ] Finance Lead approval obtained (or not required)
+- [ ] CFO approval obtained (if VAT/tax related)
+- [ ] Documentation updated (or not required)

--- a/README.md
+++ b/README.md
@@ -2,25 +2,47 @@
 
 **Owner:** Finance Lead
 
-This repository catalogs finance mappings, controls, exception definitions, close registers, and configuration references.
+Authoritative source for finance configuration data: mapping tables, control matrix, exception definitions, journal templates, fixed asset rules, and close registers. This repository does not contain code or governance documentation.
 
 ## Structure
 
 ```
 mappings/
-├── sales-invoice/   # Sales invoice field mappings
-├── debtor/          # Customer to debtor mapping rules
-├── vat/             # VAT rate to VAT code mappings
-└── account/         # Product category to GL account mappings
+├── sales-invoice/   — Sales invoice field mappings (Zoho Books → Exact)
+├── debtor/          — Customer to debtor mapping rules
+├── vat/             — VAT rate to VAT code mappings
+└── account/         — Product category to GL account mappings
 
-controls/            # Control matrix (authoritative register)
-journals/            # Journal entry templates
-fixed-assets/        # Fixed asset rules and policies
-exceptions/          # Exception category definitions
-close-checklists/    # Close checklist register
+controls/            — Control matrix (authoritative register: FINANCE_CONTROL_MATRIX.md)
+journals/            — Recurring journal entry templates
+fixed-assets/        — Fixed asset rules, thresholds, depreciation methods
+exceptions/          — Exception category definitions and severity levels
+close-checklists/    — Close checklist register (completed periods)
 ```
 
-## Rules
+## Key Documents
+
+| Document | Purpose |
+|---|---|
+| [FINANCE_CONTROL_MATRIX.md](controls/FINANCE_CONTROL_MATRIX.md) | Authoritative register for all 26 finance controls |
+| [exception-catalog.md](exceptions/exception-catalog.md) | Exception categories, severities, aging rules |
+| [sales-invoice-field-mapping.md](mappings/sales-invoice/sales-invoice-field-mapping.md) | Zoho Books → Exact field mapping |
+
+## Pull Request Template
+
+This repo uses a lightly specialized PR template that prompts for affected configuration objects (mapping IDs, control IDs, journal templates) and downstream coordination with finance-automation. The specialization exists because config changes directly affect runtime behavior and must be coordinated with code updates.
+
+## Change Rules
+
 - All changes require Finance Lead approval via PR review
 - VAT and tax-related changes also require CFO review
-- If a catalog entry is wrong, fix it immediately
+- Mapping changes must be coordinated with `finance-automation` code updates
+- Control matrix changes require documented justification
+
+## Consumed By
+
+| Consumer | What it reads |
+|---|---|
+| finance-automation | Mapping tables, validation rules, exception categories |
+| finance-runbooks | Control matrix, exception catalog, journal templates |
+| finance-governance | References control matrix (via pointer, not copy) |

--- a/controls/FINANCE_CONTROL_MATRIX.md
+++ b/controls/FINANCE_CONTROL_MATRIX.md
@@ -1,0 +1,427 @@
+# Finance Control Matrix
+
+**Owner:** Finance Lead
+**Version:** v2.0 — 2026-04-04
+**Status:** Active
+
+This is the authoritative register for all finance domain controls. All control references in other repositories point here.
+
+---
+
+## Sales Invoice Controls
+
+### CTRL-SI-001 — Sync Completeness
+
+| Attribute | Value |
+|---|---|
+| **Objective** | Ensure all sales invoices from Zoho Books are synced to Exact Online |
+| **Type** | Detective |
+| **Trigger / Frequency** | Daily (automated sync report) |
+| **Input** | Zoho Books invoice count + Exact Online posted count |
+| **Control action** | Compare counts. Any delta triggers investigation. |
+| **Owner** | Technical Lead (detection), Finance Lead (resolution) |
+| **Evidence** | Sync report with counts, timestamps, and delta |
+| **Exception handling** | Log missing invoices as exception EX-SI. Investigate within 1 BD. |
+| **Remediation** | Re-trigger sync for failed items. If structural: raise change request. |
+
+### CTRL-SI-002 — Mapping Validation
+
+| Attribute | Value |
+|---|---|
+| **Objective** | Prevent incorrectly mapped invoices from posting to Exact |
+| **Type** | Preventive |
+| **Trigger / Frequency** | Per transaction (before posting) |
+| **Input** | Invoice data from Zoho Books + mapping tables from finance-config-catalog |
+| **Control action** | Validate debtor, VAT code, GL account, and currency against mapping tables. Reject on any failure. |
+| **Owner** | Technical Lead (automated), Finance Lead (exception resolution) |
+| **Evidence** | Validation log per invoice (pass/fail per rule V-01 to V-08) |
+| **Exception handling** | Failed validations logged as exception EX-SI. Invoice not posted until resolved. |
+| **Remediation** | Update mapping table or correct source data. Re-validate and post. |
+
+### CTRL-SI-003 — Debtor Consistency
+
+| Attribute | Value |
+|---|---|
+| **Objective** | Ensure debtor records are consistent between Zoho Books and Exact Online |
+| **Type** | Detective |
+| **Trigger / Frequency** | Weekly |
+| **Input** | Debtor list from Zoho Books + debtor list from Exact Online |
+| **Control action** | Compare active debtors. Flag unmapped or inconsistent records. |
+| **Owner** | Finance Lead |
+| **Evidence** | Debtor comparison report |
+| **Exception handling** | Unmapped debtors logged as exception. New debtors added to mapping table. |
+| **Remediation** | Update debtor mapping in finance-config-catalog. Verify sync for affected invoices. |
+
+### CTRL-SI-004 — Duplicate Detection
+
+| Attribute | Value |
+|---|---|
+| **Objective** | Prevent duplicate sales invoices from being posted to Exact Online |
+| **Type** | Preventive |
+| **Trigger / Frequency** | Per transaction (before posting) |
+| **Input** | Invoice number (with ZB- prefix) |
+| **Control action** | Check if invoice reference already exists in Exact. Reject if duplicate. |
+| **Owner** | Technical Lead (automated) |
+| **Evidence** | Duplicate check log |
+| **Exception handling** | Duplicate flagged, invoice not posted. Finance Lead investigates. |
+| **Remediation** | Determine if true duplicate (discard) or numbering issue (correct and re-process). |
+
+### CTRL-SI-005 — VAT Code Validation
+
+| Attribute | Value |
+|---|---|
+| **Objective** | Ensure correct VAT codes on all sales invoices entering Exact |
+| **Type** | Preventive |
+| **Trigger / Frequency** | Per transaction (before posting) |
+| **Input** | Tax percentage from Zoho Books + VAT mapping table |
+| **Control action** | Map tax percentage to Exact VAT code. Reject if no valid mapping exists. |
+| **Owner** | Technical Lead (automated), Finance Lead (mapping maintenance) |
+| **Evidence** | VAT validation log per invoice |
+| **Exception handling** | Unmapped VAT percentage logged as exception. Invoice held until resolved. |
+| **Remediation** | Add VAT mapping or correct source data. Finance Lead approval required for new VAT mappings. |
+
+---
+
+## Purchase Controls
+
+### CTRL-PU-001 — Invoice Completeness
+
+| Attribute | Value |
+|---|---|
+| **Objective** | Ensure all purchase invoices are processed in Exact Online |
+| **Type** | Detective |
+| **Trigger / Frequency** | Weekly |
+| **Input** | Purchase invoice register in Exact Online |
+| **Control action** | Review for unprocessed invoices, follow up on outstanding items |
+| **Owner** | Finance Lead |
+| **Evidence** | Purchase processing status report |
+| **Exception handling** | Unprocessed invoices logged. Investigate reason for delay. |
+| **Remediation** | Process outstanding invoices. If systemic: raise improvement issue. |
+
+### CTRL-PU-002 — Invoice Approval
+
+| Attribute | Value |
+|---|---|
+| **Objective** | Ensure all purchase invoices are approved before payment |
+| **Type** | Preventive |
+| **Trigger / Frequency** | Per transaction |
+| **Input** | Purchase invoice in Exact Online |
+| **Control action** | Verify approval workflow completed before payment processing |
+| **Owner** | Finance Lead |
+| **Evidence** | Approval audit trail in Exact Online |
+| **Exception handling** | Unapproved invoices flagged. Payment blocked until approved. |
+| **Remediation** | Obtain approval or reject invoice. |
+
+### CTRL-PU-003 — Creditor Review
+
+| Attribute | Value |
+|---|---|
+| **Objective** | Identify aged or unusual creditor balances |
+| **Type** | Detective |
+| **Trigger / Frequency** | Monthly |
+| **Input** | Creditor aging report from Exact Online |
+| **Control action** | Review balances > 60 days. Investigate unusual amounts or suppliers. |
+| **Owner** | Finance Lead |
+| **Evidence** | Reviewed aging report with notes |
+| **Exception handling** | Unusual items logged for investigation. |
+| **Remediation** | Follow up with suppliers. Write off if appropriate (Finance Lead + CFO approval). |
+
+---
+
+## Bank Controls
+
+### CTRL-BK-001 — Import Completeness
+
+| Attribute | Value |
+|---|---|
+| **Objective** | Ensure all bank statements are imported into Exact Online |
+| **Type** | Detective |
+| **Trigger / Frequency** | Daily |
+| **Input** | Bank portal statement dates vs Exact Online import dates |
+| **Control action** | Verify latest import date matches latest available statement |
+| **Owner** | Finance Lead |
+| **Evidence** | Import log with dates |
+| **Exception handling** | Missing statements flagged. Import manually if automated feed fails. |
+| **Remediation** | Re-import missing statements. If feed issue: raise incident. |
+
+### CTRL-BK-002 — Matching Completeness
+
+| Attribute | Value |
+|---|---|
+| **Objective** | Ensure all bank transactions are matched to accounting entries |
+| **Type** | Detective |
+| **Trigger / Frequency** | Weekly |
+| **Input** | Unmatched transaction list from Exact Online |
+| **Control action** | Review and match unmatched items. Document items that cannot be matched. |
+| **Owner** | Finance Lead |
+| **Evidence** | Matching status report |
+| **Exception handling** | Persistently unmatched items logged as exception. |
+| **Remediation** | Match to existing entry or create new entry with documentation. |
+
+### CTRL-BK-003 — Balance Reconciliation
+
+| Attribute | Value |
+|---|---|
+| **Objective** | Ensure Exact Online bank balance matches actual bank statement balance |
+| **Type** | Detective |
+| **Trigger / Frequency** | Monthly |
+| **Input** | Exact Online GL bank balance + bank statement balance |
+| **Control action** | Reconcile balances. Document all reconciling items. |
+| **Owner** | Finance Lead |
+| **Evidence** | Completed reconciliation (use reconciliation template) |
+| **Exception handling** | Unexplained differences logged. Investigate before close. |
+| **Remediation** | Post adjusting entries or correct matching. Finance Lead approval. |
+
+---
+
+## Journal Controls
+
+### CTRL-JN-001 — Entry Approval
+
+| Attribute | Value |
+|---|---|
+| **Objective** | Ensure all manual journal entries are approved before posting |
+| **Type** | Preventive |
+| **Trigger / Frequency** | Per transaction |
+| **Input** | Journal entry with supporting documentation |
+| **Control action** | Finance Lead reviews and approves each manual journal before posting |
+| **Owner** | Finance Lead |
+| **Evidence** | Approval record per journal entry |
+| **Exception handling** | Unapproved journals may not be posted. |
+| **Remediation** | Obtain approval or withdraw entry. |
+
+### CTRL-JN-002 — Recurring Verification
+
+| Attribute | Value |
+|---|---|
+| **Objective** | Ensure recurring journal entries match approved templates |
+| **Type** | Detective |
+| **Trigger / Frequency** | Monthly |
+| **Input** | Posted recurring entries vs journal templates (finance-config-catalog/journals/) |
+| **Control action** | Compare posted amounts and accounts to template. Flag deviations. |
+| **Owner** | Finance Lead |
+| **Evidence** | Template comparison report |
+| **Exception handling** | Deviations logged. Finance Lead investigates. |
+| **Remediation** | Correct entry or update template (with approval). |
+
+### CTRL-JN-003 — Entry Documentation
+
+| Attribute | Value |
+|---|---|
+| **Objective** | Ensure every journal entry has adequate supporting documentation |
+| **Type** | Preventive |
+| **Trigger / Frequency** | Per transaction |
+| **Input** | Journal entry in Exact Online |
+| **Control action** | Verify supporting documentation is attached or referenced before posting |
+| **Owner** | Finance Lead |
+| **Evidence** | Journal entry with attached support |
+| **Exception handling** | Entries without support may not be posted. |
+| **Remediation** | Obtain supporting documentation before posting. |
+
+---
+
+## Fixed Asset Controls
+
+### CTRL-FA-001 — Register Completeness
+
+| Attribute | Value |
+|---|---|
+| **Objective** | Ensure the asset register in Exact Online reflects all known assets |
+| **Type** | Detective |
+| **Trigger / Frequency** | Monthly |
+| **Input** | Asset register from Exact Online |
+| **Control action** | Review register against known additions, disposals, and physical inventory |
+| **Owner** | Finance Lead |
+| **Evidence** | Reviewed asset register with notes |
+| **Exception handling** | Missing or unrecognized assets logged for investigation. |
+| **Remediation** | Add missing assets or dispose of phantom assets (with approval). |
+
+### CTRL-FA-002 — Depreciation Review
+
+| Attribute | Value |
+|---|---|
+| **Objective** | Ensure depreciation calculations are reasonable and correct |
+| **Type** | Detective |
+| **Trigger / Frequency** | Monthly |
+| **Input** | Depreciation calculation output from Exact Online |
+| **Control action** | Preview depreciation run. Compare to expected amounts. Review for reasonableness. |
+| **Owner** | Finance Lead |
+| **Evidence** | Depreciation preview report with review notes |
+| **Exception handling** | Unreasonable amounts flagged. Do not post until investigated. |
+| **Remediation** | Correct asset data or depreciation parameters. Re-run preview. |
+
+### CTRL-FA-003 — Addition/Disposal Approval
+
+| Attribute | Value |
+|---|---|
+| **Objective** | Ensure all asset additions and disposals are properly authorized |
+| **Type** | Preventive |
+| **Trigger / Frequency** | Per transaction |
+| **Input** | Asset addition or disposal request |
+| **Control action** | Finance Lead approves before processing in Exact Online |
+| **Owner** | Finance Lead |
+| **Evidence** | Approval record for each addition/disposal |
+| **Exception handling** | Unapproved additions/disposals may not be processed. |
+| **Remediation** | Obtain approval or reject request. |
+
+---
+
+## VAT/Tax Controls
+
+### CTRL-VT-001 — Return Reconciliation
+
+| Attribute | Value |
+|---|---|
+| **Objective** | Ensure VAT return amounts reconcile to the general ledger |
+| **Type** | Detective |
+| **Trigger / Frequency** | Monthly (preparation), Quarterly (filing) |
+| **Input** | VAT return data + GL VAT account balances from Exact Online |
+| **Control action** | Reconcile VAT return amounts to GL. Document all differences. |
+| **Owner** | Finance Lead |
+| **Evidence** | VAT reconciliation (use reconciliation template) |
+| **Exception handling** | Unexplained differences investigated before filing. |
+| **Remediation** | Post correcting entries or adjust return. Finance Lead + CFO approval for material adjustments. |
+
+### CTRL-VT-002 — Code Usage Review
+
+| Attribute | Value |
+|---|---|
+| **Objective** | Ensure transactions are coded with correct VAT codes |
+| **Type** | Detective |
+| **Trigger / Frequency** | Monthly |
+| **Input** | Transaction listing by VAT code from Exact Online |
+| **Control action** | Review transaction sample per VAT code for correctness |
+| **Owner** | Finance Lead |
+| **Evidence** | Reviewed transaction sample with notes |
+| **Exception handling** | Incorrectly coded transactions flagged for correction. |
+| **Remediation** | Post correcting entries. If systemic: update mapping rules and raise change request. |
+
+### CTRL-VT-003 — Reverse Charge Verification
+
+| Attribute | Value |
+|---|---|
+| **Objective** | Ensure reverse charge VAT is correctly applied where required |
+| **Type** | Detective |
+| **Trigger / Frequency** | Monthly |
+| **Input** | Reverse charge transactions from Exact Online |
+| **Control action** | Verify reverse charge applied to correct supplier/transaction types |
+| **Owner** | Finance Lead |
+| **Evidence** | Reverse charge review report |
+| **Exception handling** | Missing or incorrect reverse charge flagged. |
+| **Remediation** | Post correcting entries. Update supplier or VAT settings. |
+
+---
+
+## Close Controls
+
+### CTRL-MC-001 — Checklist Completion
+
+| Attribute | Value |
+|---|---|
+| **Objective** | Ensure all close tasks are completed before period close |
+| **Type** | Detective |
+| **Trigger / Frequency** | Monthly (during close) |
+| **Input** | Close checklist for the period |
+| **Control action** | Verify every task is marked complete with evidence before final close |
+| **Owner** | Finance Lead |
+| **Evidence** | Completed close checklist |
+| **Exception handling** | Incomplete items must be resolved or deferred (with documented justification). |
+| **Remediation** | Complete outstanding tasks or document deferral reason. |
+
+### CTRL-MC-002 — Balance Sheet Review
+
+| Attribute | Value |
+|---|---|
+| **Objective** | Ensure all balance sheet accounts are reviewed and balances are explained |
+| **Type** | Detective |
+| **Trigger / Frequency** | Monthly (Phase 3 of close) |
+| **Input** | Trial balance from Exact Online |
+| **Control action** | Review each BS account. Confirm balance is expected and supported. |
+| **Owner** | Finance Lead |
+| **Evidence** | BS review notes per account |
+| **Exception handling** | Unexplained balances flagged. Investigate before close. |
+| **Remediation** | Post adjusting entries or obtain explanation. |
+
+### CTRL-MC-003 — P&L Variance Analysis
+
+| Attribute | Value |
+|---|---|
+| **Objective** | Identify and explain material P&L variances |
+| **Type** | Detective |
+| **Trigger / Frequency** | Monthly (Phase 3 of close) |
+| **Input** | P&L actual vs budget, P&L actual vs prior period |
+| **Control action** | Identify variances exceeding materiality threshold. Document explanations. |
+| **Owner** | Finance Lead |
+| **Evidence** | Variance analysis with explanations |
+| **Exception handling** | Unexplained material variances escalated to CFO. |
+| **Remediation** | Investigate, post correcting entries if needed, document root cause. |
+
+### CTRL-MC-004 — Period Close Approval
+
+| Attribute | Value |
+|---|---|
+| **Objective** | Ensure period close is explicitly approved before execution |
+| **Type** | Preventive |
+| **Trigger / Frequency** | Monthly (Phase 4 of close) |
+| **Input** | Close package (checklist, reconciliations, variance analysis, control results) |
+| **Control action** | Finance Lead and CFO review close package and approve period close |
+| **Owner** | Finance Lead + CFO |
+| **Evidence** | Signed approval (name + date) |
+| **Exception handling** | Close does not proceed without approval. Objections documented and addressed. |
+| **Remediation** | Address objections, re-submit for approval. |
+
+---
+
+## Exception Controls
+
+### CTRL-EX-001 — Aging Review
+
+| Attribute | Value |
+|---|---|
+| **Objective** | Prevent exceptions from aging without attention |
+| **Type** | Detective |
+| **Trigger / Frequency** | Weekly |
+| **Input** | Open exception register (GitHub issues) |
+| **Control action** | Review all exceptions open > 5 business days. Escalate if needed. |
+| **Owner** | Finance Lead |
+| **Evidence** | Exception aging report with actions taken |
+| **Exception handling** | Exceptions > 10 BD escalated. Owner reassignment if needed. |
+| **Remediation** | Resolve, reassign, or escalate. Document actions taken. |
+
+### CTRL-EX-002 — Resolution Documentation
+
+| Attribute | Value |
+|---|---|
+| **Objective** | Ensure every resolved exception has documented resolution |
+| **Type** | Preventive |
+| **Trigger / Frequency** | Per resolution |
+| **Input** | Resolved exception (GitHub issue) |
+| **Control action** | Verify resolution includes: root cause, actions taken, preventive measures, evidence |
+| **Owner** | Finance Lead |
+| **Evidence** | Completed exception analysis (use exception analysis template) |
+| **Exception handling** | Exceptions may not be closed without documented resolution. |
+| **Remediation** | Complete documentation before closing. |
+
+---
+
+## Assessment Schedule
+
+| Control area | Assessment frequency |
+|---|---|
+| Sales invoice (CTRL-SI-*) | Monthly |
+| Purchase (CTRL-PU-*) | Monthly |
+| Bank (CTRL-BK-*) | Monthly |
+| Journal (CTRL-JN-*) | Monthly |
+| Fixed asset (CTRL-FA-*) | Quarterly |
+| VAT/tax (CTRL-VT-*) | Quarterly |
+| Close (CTRL-MC-*) | Monthly |
+| Exception (CTRL-EX-*) | Monthly |
+
+## Maintenance
+
+Changes to this matrix require:
+1. Change request in GitHub
+2. Finance Lead approval
+3. CFO approval if control is added, removed, or materially changed
+4. Update to this document
+5. Communication to affected owners

--- a/controls/control-matrix.md
+++ b/controls/control-matrix.md
@@ -1,7 +1,9 @@
-# Control Matrix — Finance Domain
+# Control Matrix — Finance Domain (Summary Register)
+
+> **Superseded by:** [FINANCE_CONTROL_MATRIX.md](FINANCE_CONTROL_MATRIX.md) — the full control matrix with objectives, evidence, exception handling, and remediation per control.
 
 ## Version
-v1.0 — 2026-04-04
+v1.0 — 2026-04-04 (superseded by v2.0)
 
 ## Control Register
 
@@ -47,6 +49,6 @@ v1.0 — 2026-04-04
 
 ## Maintenance
 
-This matrix is the authoritative register. It is maintained in `finance-config-catalog` and referenced by the control framework in `finance-product`.
+The authoritative register is now `FINANCE_CONTROL_MATRIX.md` in this directory. It is referenced by the control framework pointer in `finance-governance`.
 
 Changes follow the standard change process with Finance Lead approval.

--- a/issues/CFG-001-apply-labels.md
+++ b/issues/CFG-001-apply-labels.md
@@ -1,0 +1,30 @@
+# CFG-001: Apply labels to finance-config-catalog
+
+**Repo:** finance-config-catalog
+**Owner type:** Technical Lead
+**Labels:** `type:tech-debt`, `area:configuration`, `system:github`, `priority:critical`
+**Milestone:** foundation-baseline
+
+## Objective
+
+Create the full label set so issues can be properly categorized.
+
+## Scope
+
+Run the label creation script against this repository. Same 40 labels as all finance repos.
+
+## Dependencies
+
+None.
+
+## Acceptance Criteria
+
+- [ ] All 40 labels created
+
+## Definition of Done
+
+`gh label list -R {owner}/finance-config-catalog` returns 40 labels.
+
+## Execution
+
+Same script as GOV-001, replace `REPO="{owner}/finance-config-catalog"`.

--- a/issues/CFG-002-branch-protection.md
+++ b/issues/CFG-002-branch-protection.md
@@ -1,0 +1,43 @@
+# CFG-002: Enable branch protection on main
+
+**Repo:** finance-config-catalog
+**Owner type:** Technical Lead
+**Labels:** `type:tech-debt`, `area:configuration`, `system:github`, `priority:critical`
+**Milestone:** foundation-baseline
+
+## Objective
+
+Protect the main branch so all config changes require a reviewed PR.
+
+## Scope
+
+Same protection as other repos: required PR, 1 approval, stale review dismissal, no force push, no deletion.
+
+## Dependencies
+
+None.
+
+## Acceptance Criteria
+
+- [ ] Direct pushes to main blocked
+- [ ] PRs require 1 approving review
+- [ ] Stale reviews dismissed
+- [ ] Force pushes disabled
+
+## Definition of Done
+
+`gh api repos/{owner}/finance-config-catalog/branches/main/protection` returns HTTP 200.
+
+## Execution
+
+```bash
+gh api repos/{owner}/finance-config-catalog/branches/main/protection \
+  -X PUT \
+  -F "required_pull_request_reviews[required_approving_review_count]=1" \
+  -F "required_pull_request_reviews[dismiss_stale_reviews]=true" \
+  -F "enforce_admins=false" \
+  -F "restrictions=null" \
+  -F "required_status_checks=null" \
+  -F "allow_force_pushes=false" \
+  -F "allow_deletions=false"
+```

--- a/issues/CFG-003-codeowners.md
+++ b/issues/CFG-003-codeowners.md
@@ -1,0 +1,36 @@
+# CFG-003: Create CODEOWNERS file
+
+**Repo:** finance-config-catalog
+**Owner type:** Technical Lead
+**Labels:** `type:tech-debt`, `area:configuration`, `system:github`, `priority:critical`
+**Milestone:** foundation-baseline
+
+## Objective
+
+Auto-assign Finance Lead as reviewer for all PRs in this repo.
+
+## Dependencies
+
+CFG-002 (branch protection must be enabled).
+
+## Acceptance Criteria
+
+- [ ] `CODEOWNERS` file exists at repo root
+- [ ] PRs automatically request review from Finance Lead
+
+## Definition of Done
+
+Open a test PR. Verify Finance Lead is auto-requested. Close test PR.
+
+## File Content
+
+```
+# Finance config — Finance Lead owns all config
+* @{finance-lead-username}
+
+# Control matrix changes require Finance Lead
+/controls/ @{finance-lead-username}
+
+# Mapping changes require Finance Lead
+/mappings/ @{finance-lead-username}
+```

--- a/issues/CFG-004-debtor-mapping-live.md
+++ b/issues/CFG-004-debtor-mapping-live.md
@@ -1,0 +1,94 @@
+# CFG-004: Populate debtor mapping with live data
+
+**Repo:** finance-config-catalog
+**Owner type:** Finance Lead
+**Labels:** `type:change`, `area:sales-invoice`, `area:configuration`, `system:exact-online`, `system:zoho-books`, `process:requires-finance-approval`, `control:medium-impact`, `priority:critical`
+**Milestone:** first-pilot
+
+---
+
+## Purpose
+
+Replace the example debtor mapping entry with actual Zoho Books customer → Exact Online debtor code data. This is the first pilot of the governed config change flow and a prerequisite for any sales invoice sync.
+
+## Config Objects Affected
+
+- `mappings/debtor/debtor-mapping-rules.md` — Mapping Table section
+
+## Governance References
+
+- Governed handoff: `finance-governance/ZOHOBOOKS_TO_EXACT_GOVERNED_HANDOFF.md` section 5 (field mapping, header row 1: customer_id → Debtor code via lookup)
+- Validation rule: V-01 — Debtor must exist in Exact Online
+- Control: CTRL-SI-003 — Debtor consistency
+- PR template: finance-config-catalog specialized template (downstream coordination section)
+
+## Required Approvals
+
+- Finance Lead (required — owns mapping data)
+- CFO: not required (no VAT/tax impact)
+
+## Scope
+
+### In scope
+- Export active customer list from Zoho Books (customer_id + customer name)
+- Export debtor list from Exact Online (debtor code + debtor name)
+- Match each active Zoho Books customer to an Exact Online debtor
+- Add all matched entries to the mapping table
+- Flag any Zoho Books customers without an Exact debtor (these need debtor creation first)
+- Mark example row as removed or replaced
+
+### Out of scope
+- Creating new debtors in Exact Online (separate action, outside this issue)
+- Changing the mapping format or rules
+- Updating automation code (mapping format is unchanged)
+
+## Execution Steps
+
+1. Export active customers from Zoho Books (customer_id, customer_name)
+2. Export active debtors from Exact Online (debtor_code, debtor_name)
+3. Match by customer name (or known correspondence)
+4. Create feature branch: `feature/mapping-debtor-live-data`
+5. Edit `mappings/debtor/debtor-mapping-rules.md`:
+   - Remove the example row
+   - Add one row per active customer with: customer_id, customer name, debtor code, debtor name, Status=Active, added date
+6. Open PR using config-catalog PR template
+7. Fill in all sections:
+   - **Affected configuration objects:** debtor mapping table
+   - **Downstream coordination:** No automation code change needed — mapping format unchanged, only data populated
+   - **Validation performed:** Cross-checked Zoho Books customer list against Exact Online debtor list
+8. Finance Lead reviews data accuracy
+9. Merge after approval
+10. Close this issue with PR link
+
+## Validation Method
+
+- Every active Zoho Books customer that generates invoices has a row in the mapping table
+- Every debtor code in the table exists as an active debtor in Exact Online
+- No duplicate customer_id entries
+- No duplicate debtor code entries (one debtor per customer)
+
+## Rollback Method
+
+Revert the PR commit. The example row returns. No production impact — sync automation is not yet live.
+
+## Evidence Required at Closure
+
+- [ ] PR link with completed template
+- [ ] Approval from Finance Lead on the PR
+- [ ] Number of customers mapped (documented in PR description)
+- [ ] List of unmapped customers (if any) with explanation
+- [ ] Merged to main
+
+## Acceptance Criteria
+
+- [ ] All active Zoho Books customers with invoice history have a mapping entry
+- [ ] All debtor codes verified against Exact Online
+- [ ] Example row removed
+- [ ] Finance Lead approved the PR
+- [ ] PR merged to main
+- [ ] Issue closed with PR link
+- [ ] Any unmapped customers documented as follow-up issues
+
+## Notes
+
+This is the first pilot issue. It tests the full governed flow: issue → branch → PR → review → merge. Document any friction or gaps as improvement issues.

--- a/issues/CFG-005-vat-mapping-live.md
+++ b/issues/CFG-005-vat-mapping-live.md
@@ -1,0 +1,93 @@
+# CFG-005: Verify and complete VAT mapping with live data
+
+**Repo:** finance-config-catalog
+**Owner type:** Finance Lead
+**Labels:** `type:change`, `area:vat-tax`, `area:configuration`, `system:exact-online`, `system:zoho-books`, `process:requires-finance-approval`, `process:requires-cfo-approval`, `control:high-impact`, `priority:critical`
+**Milestone:** first-pilot
+
+---
+
+## Purpose
+
+Verify that the existing VAT mapping table matches the actual Zoho Books tax rates and Exact Online VAT codes in use. Add any missing mappings. This directly affects V-02 validation and has high control impact.
+
+## Config Objects Affected
+
+- `mappings/vat/vat-mapping-rules.md` — Mapping Table section
+
+## Governance References
+
+- Governed handoff: `finance-governance/ZOHOBOOKS_TO_EXACT_GOVERNED_HANDOFF.md` section 5 (line field 3: tax_percentage → VAT code via lookup)
+- Validation rule: V-02 — VAT code must match Exact allowed values
+- Control: CTRL-SI-005 — VAT code validation
+- Change process: requires Finance Lead + CFO approval (VAT-sensitive)
+
+## Required Approvals
+
+- Finance Lead (required)
+- CFO (required — VAT/tax-related change)
+
+## Scope
+
+### In scope
+- Export all tax rates used on invoices in Zoho Books
+- Export all VAT codes configured in Exact Online
+- Cross-check current mapping table against both sources
+- Add any missing mappings
+- Correct any incorrect mappings
+- Confirm that the 5 existing entries (21%, 9%, 0%, reverse charge EU, export) are correct for this administration
+
+### Out of scope
+- Changing Zoho Books tax rate configuration
+- Changing Exact Online VAT code configuration
+- Modifying the automation validation logic
+
+## Execution Steps
+
+1. In Zoho Books: list all tax rates used on invoices in the last 12 months
+2. In Exact Online: list all active VAT codes
+3. Compare to the current 5-row mapping table
+4. Create feature branch: `feature/mapping-vat-verify-live`
+5. Edit `mappings/vat/vat-mapping-rules.md`:
+   - Correct any mismatches
+   - Add missing rate → code combinations
+   - Verify the descriptions match Exact Online labels
+6. Open PR using config-catalog PR template
+7. Fill in:
+   - **Affected configuration objects:** VAT mapping table
+   - **Downstream coordination:** No automation code change needed — mapping format unchanged
+   - **Validation performed:** Cross-checked against Zoho Books tax rates and Exact Online VAT codes
+8. Finance Lead reviews
+9. CFO reviews (VAT-sensitive)
+10. Merge after both approvals
+11. Close issue with PR link
+
+## Validation Method
+
+- Every tax rate used on Zoho Books invoices in the last 12 months has a mapping entry
+- Every VAT code in the table exists and is active in Exact Online
+- Descriptions match Exact Online VAT code descriptions
+- No duplicate tax_percentage entries (except where the same rate maps differently based on transaction type, which must be documented)
+
+## Rollback Method
+
+Revert the PR commit. Previous mapping table is restored. No production impact — sync automation is not yet live.
+
+## Evidence Required at Closure
+
+- [ ] PR link with completed template
+- [ ] Finance Lead approval on PR
+- [ ] CFO approval on PR
+- [ ] List of tax rates verified (documented in PR description)
+- [ ] Any new mappings added (documented)
+- [ ] Any corrections made (documented with reason)
+- [ ] Merged to main
+
+## Acceptance Criteria
+
+- [ ] All Zoho Books tax rates in use have a valid mapping
+- [ ] All VAT codes verified against Exact Online
+- [ ] Finance Lead approved
+- [ ] CFO approved
+- [ ] PR merged to main
+- [ ] Issue closed with PR link

--- a/issues/CFG-006-account-mapping-live.md
+++ b/issues/CFG-006-account-mapping-live.md
@@ -1,0 +1,91 @@
+# CFG-006: Verify and complete account mapping with live data
+
+**Repo:** finance-config-catalog
+**Owner type:** Finance Lead
+**Labels:** `type:change`, `area:sales-invoice`, `area:configuration`, `system:exact-online`, `process:requires-finance-approval`, `control:medium-impact`, `priority:critical`
+**Milestone:** first-pilot
+
+---
+
+## Purpose
+
+Verify that the existing account mapping table matches the actual Zoho Books product categories and Exact Online GL accounts in use. Add any missing mappings. This directly affects V-03 validation.
+
+## Config Objects Affected
+
+- `mappings/account/account-mapping-rules.md` — Mapping Table section
+
+## Governance References
+
+- Governed handoff: `finance-governance/ZOHOBOOKS_TO_EXACT_GOVERNED_HANDOFF.md` section 5 (line field 6: product_category → GL account via lookup)
+- Validation rule: V-03 — GL account must exist in Exact chart of accounts
+- PR template: finance-config-catalog specialized template
+
+## Required Approvals
+
+- Finance Lead (required — GL account mapping is a financial control)
+- CFO: not required (unless GL structure is changed, which is out of scope)
+
+## Scope
+
+### In scope
+- Export all product/service categories used on invoices in Zoho Books
+- Export the relevant revenue GL accounts from Exact Online chart of accounts
+- Cross-check the current 5-row mapping table against both sources
+- Add missing category → GL account combinations
+- Verify the "default" fallback account (8000) exists and is correct
+- Confirm GL account descriptions match Exact Online
+
+### Out of scope
+- Adding new GL accounts to Exact Online (separate action)
+- Changing Zoho Books product category structure
+- Modifying the automation validation logic
+
+## Execution Steps
+
+1. In Zoho Books: list all product/service categories used on invoices in the last 12 months
+2. In Exact Online: export revenue accounts (8000-8999 range or equivalent)
+3. Compare to the current 5-row mapping table
+4. Create feature branch: `feature/mapping-account-verify-live`
+5. Edit `mappings/account/account-mapping-rules.md`:
+   - Add missing category → GL account combinations
+   - Verify existing entries match Exact Online
+   - Confirm default account exists
+6. Open PR using config-catalog PR template
+7. Fill in:
+   - **Affected configuration objects:** account mapping table
+   - **Downstream coordination:** No automation code change needed — mapping format unchanged
+   - **Validation performed:** Cross-checked against Zoho Books categories and Exact Online chart of accounts
+8. Finance Lead reviews
+9. Merge after approval
+10. Close issue with PR link
+
+## Validation Method
+
+- Every product category used on Zoho Books invoices in the last 12 months has a mapping entry
+- Every GL account in the table exists in the Exact Online chart of accounts
+- GL account descriptions match Exact Online
+- Default fallback account exists and is correct
+- No duplicate category entries
+
+## Rollback Method
+
+Revert the PR commit. Previous mapping table is restored. No production impact.
+
+## Evidence Required at Closure
+
+- [ ] PR link with completed template
+- [ ] Finance Lead approval on PR
+- [ ] List of categories verified (documented in PR description)
+- [ ] Any new mappings added (documented)
+- [ ] Default account confirmed
+- [ ] Merged to main
+
+## Acceptance Criteria
+
+- [ ] All active Zoho Books product categories have a mapping entry
+- [ ] All GL accounts verified against Exact Online chart of accounts
+- [ ] Default account confirmed
+- [ ] Finance Lead approved
+- [ ] PR merged to main
+- [ ] Issue closed with PR link


### PR DESCRIPTION
## Summary
Apply the accepted Finance domain normalization to finance-config-catalog.

## Affected configuration objects
- README.md — rewritten
- FINANCE_CONTROL_MATRIX.md — new authoritative 26-control register
- control-matrix.md — marked as superseded
- .github/ — issue templates (3) and specialized PR template added
- issues/ — execution issue templates CFG-001 through CFG-006

## Control impact
Low — adds governance structure, does not change config data

## Downstream coordination
- [x] No automation code change needed

## Validation performed
Content matches accepted governance documents in finance-governance.

## Rollback approach
Revert the merge commit.